### PR TITLE
Add an overlay function for tracing images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
                         <div id="save-ansi" class="menu-item">Save as ANSi</div>
                         <div id="save-bin" class="menu-item">Save as Binary Text</div>
                         <div id="save-xbin" class="menu-item">Save as XBin</div>
+                        <div id="trace" class="menu-item">Load overlay</div>
                         <div class="seperator"></div>
                         <div id="save-png" class="menu-item">Export as PNG</div>
                         <div id="save-utf8" class="menu-item">Export as ANSi (UTF-8)</div>
@@ -54,6 +55,7 @@
                         <div id="fonts" class="menu-item excluded-for-websocket">Change Font</div>
                         <div class="seperator excluded-for-websocket"></div>
                         <div id="grid-toggle" class="menu-item">Show Grid (Ctrl-G)</div>
+                        <div id="trace-toggle" class="menu-item">Show Overlay</div>
                         <div class="seperator included-for-websocket"></div>
                         <div id="chat-toggle" class="included-for-websocket menu-item">Show Chat (Escape)</div>
                     </div>

--- a/public/scripts/document_onload.js
+++ b/public/scripts/document_onload.js
@@ -3,6 +3,7 @@ var title;
 var palette;
 var font;
 var textArtCanvas;
+var traceCanvas;
 var cursor;
 var selectionCursor;
 var positionInfo;
@@ -78,6 +79,47 @@ document.addEventListener("DOMContentLoaded", () => {
         onClick($("open-cancel"), () => {
             hideOverlay($("open-overlay"));
         });
+
+
+        onClick($("trace"), () => {
+            showOverlay($("trace-overlay"));
+        });
+        onFileChange($("open-trace-file"), (file) => {
+            var currentCanvas = $("canvas-container");
+            traceCanvas = createCanvas( currentCanvas.offsetWidth, currentCanvas.offsetHeight );
+            traceCanvas.id = "trace-canvas";
+            $("canvas-container").prepend(traceCanvas);
+            $("trace-canvas").classList.add("visible");
+            $("trace-toggle").classList.add("enabled");
+            var traceCtx = traceCanvas.getContext("2d");
+
+            var reader = new FileReader();
+            reader.addEventListener("load", function (evt) {
+                var traceImg = new Image();
+                traceImg.src = reader.result;
+                traceImg.onload = function() {
+                    var hRatio = traceCanvas.width / traceImg.width;
+                    var vRatio = traceCanvas.height / traceImg.height;
+                    var ratio  = Math.min ( hRatio, vRatio );
+                    var centerShift_x = ( traceCanvas.width - traceImg.width*ratio ) / 2;
+                    var centerShift_y = ( traceCanvas.height - traceImg.height*ratio ) / 2;  
+                    traceCtx.drawImage(
+                        traceImg, 
+                        0, 0, traceImg.width, traceImg.height, 
+                        centerShift_x, centerShift_y, traceImg.width*ratio, traceImg.height*ratio
+                    );
+                }
+                hideOverlay($("trace-overlay"));
+                $("open-trace-file").value = "";
+            });
+            reader.readAsDataURL(file);
+        });
+        onClick($("open-trace-cancel"), () => {
+            hideOverlay($("trace-overlay"));
+        });
+
+
+
         onClick($("edit-sauce"), () => {
             showOverlay($("sauce-overlay"));
             keyboard.ignore();
@@ -179,6 +221,29 @@ document.addEventListener("DOMContentLoaded", () => {
         });
         var grid = createGrid($("grid"));
         var gridToggle = createSettingToggle($("grid-toggle"), grid.isShown, grid.show);
+
+        var trace = {
+            visible: function() {
+                var traceCanvas = document.getElementById("trace-canvas");
+                if (traceCanvas) {
+                    return traceCanvas.classList.contains("visible");
+                }
+                return false;
+            },
+            toggle: function( ) {
+                var traceCanvas = document.getElementById("trace-canvas");
+                if ( traceCanvas ) {
+                    if ( trace.visible() ) {
+                        traceCanvas.classList.remove("visible");
+                    }
+                    else {
+                        traceCanvas.classList.add("visible");
+                    }
+                }
+            }
+        };
+        var traceToggle = createSettingToggle( $("trace-toggle"), trace.visible , trace.toggle );
+
         var freestyle = createFreehandController(createShadingPanel());
         Toolbar.add($("freestyle"), freestyle.enable, freestyle.disable);
         var characterBrush = createFreehandController(createCharacterBrushPanel());

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -533,3 +533,14 @@ canvas.selection-cursor {
     border-left: 1px solid rgb(63, 63, 63);
     background-color: rgb(95, 95, 95);
 }
+#canvas-container canvas#trace-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0.5;
+    pointer-events: none;
+    display: none;
+}
+#canvas-container canvas#trace-canvas.visible {
+    display: block;
+}


### PR DESCRIPTION
Hey Andy,

Something I've wanted for a long time is a convenient, built-in way to trace over a source image within an ANSI editor.

I took a whack at adding that functionality to ANSIedit. Basically the user can load an "overlay" -- a canvas element is created the same size as the artwork, and the user's image is scaled to fit the canvas. It renders at 50% opacity and has pointer-events: none. I also made a toggle to turn it on/off. 

I'm sure there are things I've overlooked, but hopefully this pull request gives you the idea. If you like it, feel free to use it. If you'd rather do it a different way, that's cool. I also recognize this may not be a feature you want in ANSIEdit at all.